### PR TITLE
Implement ABI and API level filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ settings.
 
  * Index verification via jar signature - currently relies on HTTPS
  * Interaction with multiple devices at once
- * Device compatibility filters (minSdk, maxSdk, arch, hardware features)
+ * Hardware features filtering
 
 ### Advantages over the Android client
 

--- a/cmd/fdroidcl/download.go
+++ b/cmd/fdroidcl/download.go
@@ -26,12 +26,14 @@ func runDownload(args []string) {
 	}
 	apps := findApps(args)
 	for _, app := range apps {
-		apk := app.CurApk()
-		if apk == nil {
-			log.Fatalf("No current apk found for %s", app.ID)
+		apks := app.SuggestedApks()
+		if len(apks) == 0 {
+			log.Fatalf("No suggested APKs found for %s", app.ID)
 		}
-		path := downloadApk(apk)
-		fmt.Printf("APK available in %s\n", path)
+		for _, apk := range apks {
+			path := downloadApk(&apk)
+			fmt.Printf("APK available in %s\n", path)
+		}
 	}
 }
 

--- a/cmd/fdroidcl/install.go
+++ b/cmd/fdroidcl/install.go
@@ -43,9 +43,9 @@ func downloadAndDo(apps []*fdroidcl.App, device *adb.Device, doApk func(*adb.Dev
 	}
 	toInstall := make([]downloaded, len(apps))
 	for i, app := range apps {
-		apk := app.CurApk()
+		apk := app.SuggestedApk(device)
 		if apk == nil {
-			log.Fatalf("No current apk found for %s", app.ID)
+			log.Fatalf("No suitable APKs found for %s", app.ID)
 		}
 		path := downloadApk(apk)
 		toInstall[i] = downloaded{apk: apk, path: path}

--- a/cmd/fdroidcl/show.go
+++ b/cmd/fdroidcl/show.go
@@ -69,13 +69,7 @@ func printAppDetailed(app fdroidcl.App) {
 	p("Summary          :", "%s", app.Summary)
 	p("Added            :", "%s", app.Added.String())
 	p("Last Updated     :", "%s", app.Updated.String())
-	cur := app.CurApk()
-	if cur != nil {
-		p("Current Version  :", "%s (%d)", cur.VName, cur.VCode)
-	} else {
-		p("Current Version  :", "(no version available)")
-	}
-	p("Upstream Version :", "%s (%d)", app.CVName, app.CVCode)
+	p("Version          :", "%s (%d)", app.CVName, app.CVCode)
 	p("License          :", "%s", app.License)
 	if app.Categs != nil {
 		p("Categories       :", "%s", strings.Join(app.Categs, ", "))

--- a/cmd/fdroidcl/upgrade.go
+++ b/cmd/fdroidcl/upgrade.go
@@ -33,8 +33,11 @@ func runUpgrade(args []string) {
 		if !e {
 			log.Fatalf("%s is not installed", app.ID)
 		}
-		cur := app.CurApk()
-		if p.VCode >= cur.VCode {
+		suggested := app.SuggestedApk(device)
+		if suggested == nil {
+			log.Fatalf("No suitable APKs found for %s", app.ID)
+		}
+		if p.VCode >= suggested.VCode {
 			log.Fatalf("%s is up to date", app.ID)
 		}
 	}

--- a/index.go
+++ b/index.go
@@ -83,11 +83,11 @@ func getIconsDir(density IconDensity) string {
 }
 
 func (a *App) IconURLForDensity(density IconDensity) string {
-	cur := a.CurApk()
-	if cur == nil {
+	if len(a.Apks) == 0 {
 		return ""
 	}
-	return fmt.Sprintf("%s/%s/%s", cur.Repo.URL, getIconsDir(density), a.Icon)
+	return fmt.Sprintf("%s/%s/%s", a.Apks[0].Repo.URL,
+		getIconsDir(density), a.Icon)
 }
 
 func (a *App) IconURL() string {

--- a/index.go
+++ b/index.go
@@ -267,19 +267,6 @@ func LoadIndexXML(r io.Reader) (*Index, error) {
 	return &index, nil
 }
 
-func (a *App) CurApk() *Apk {
-	for i := range a.Apks {
-		apk := a.Apks[i]
-		if a.CVCode >= apk.VCode {
-			return &apk
-		}
-	}
-	if len(a.Apks) > 0 {
-		return &a.Apks[0]
-	}
-	return nil
-}
-
 func (a *App) ApksByVName(vname string) []Apk {
 	var apks []Apk
 	for i := range a.Apks {


### PR DESCRIPTION
Some ideas behind this implementation:

1. No assumptions should be made about the Android device. A particular APK is selected (for installation) only after it's checked for compatibility with the connected device.
2. Assume that user wants the latest stable version. The situation when it's not the case should be solved in the scope of #6.
3. Suggested APK is selected in the same way as in Android client.
4. This PR implements only ABI and API level checking, it does not consider hardware features.

Fixes #5.