### PR TITLE
Fix error message printed twice on invalid subcommand flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -219,9 +219,8 @@ func main1() int {
 		cmd.Fset.Init(cmdName, flag.ContinueOnError)
 		cmd.Fset.Usage = cmd.usage
 		if err := cmd.Fset.Parse(args[1:]); err != nil {
-			if err != flag.ErrHelp {
-				fmt.Fprintf(os.Stderr, "flag: %v\n", err)
-				cmd.Fset.Usage()
+			if err == flag.ErrHelp {
+				return 0
 			}
 			return 2
 		}

--- a/testdata/scripts/cmds.txt
+++ b/testdata/scripts/cmds.txt
@@ -17,12 +17,12 @@ stdout '^v0\.8'
 stderr '-badflag'
 stderr '^usage: fdroidcl \[-h'
 
-! fdroidcl search -h
+fdroidcl search -h
 stderr '^usage: fdroidcl search .*regexp'
 stderr '^Search available apps.'
 stderr '-i.*Filter installed apps'
 
-! fdroidcl install -h
+fdroidcl install -h
 stderr 'When given no arguments'
 
 ! fdroidcl


### PR DESCRIPTION
cmd.Fset.Parse prints the message already.
Also stop exiting with 2 when a subcommand is run with -h / --help.

Fixes #84 
Fixes #85